### PR TITLE
feat: Pluggable pipeline routing for task orchestration

### DIFF
--- a/forge/init/generation/generate-orchestration.md
+++ b/forge/init/generation/generate-orchestration.md
@@ -19,13 +19,22 @@ wiring in the generated atomic workflows.
 ## Instructions
 
 ### orchestrate_task.md
-1. Define each pipeline phase with concrete values:
+1. Add a **Pipeline Resolution** section at the top of the orchestrator:
+   - Read `task.pipeline` from the task manifest JSON
+   - If set, resolve it against `config.pipelines[task.pipeline]`
+   - If not set or not found, use the default pipeline
+   - For each phase in the resolved pipeline, invoke the phase's `command`
+     with the task ID as argument
+2. Define the default pipeline phases with concrete values:
    - Workflow file paths (the exact filenames generated in Phase 5)
    - Gate checks (test command, build command, lint command from config)
    - Model assignments per role
    - Max iteration counts
-2. Include error recovery strategies
-3. Include event emission format with project ID prefix
+3. For custom pipelines, the orchestrator invokes each phase's `command` as
+   a slash command (e.g., `convert-measure {TASK_ID}`). Review-role phases
+   still enforce revision loops up to `maxIterations`.
+4. Include error recovery strategies
+5. Include event emission format with project ID prefix
 
 ### run_sprint.md
 1. Define execution modes (sequential, wave-parallel, full-parallel)

--- a/forge/meta/store-schema/task.schema.md
+++ b/forge/meta/store-schema/task.schema.md
@@ -20,6 +20,7 @@
 | `planIterations` | integer | no | Number of plan review loops |
 | `codeReviewIterations` | integer | no | Number of code review loops |
 | `assignedModel` | string | no | Model used for implementation |
+| `pipeline` | string | no | Named pipeline to use instead of `default`. Must match a key in `config.pipelines`. When absent, the orchestrator uses the `default` pipeline. |
 
 ## Status Values
 

--- a/forge/meta/workflows/meta-orchestrate.md
+++ b/forge/meta/workflows/meta-orchestrate.md
@@ -17,11 +17,33 @@ Each phase has:
 - `max_iterations` — revision loop limit (for review phases)
 - `gate_checks` — conditions that must pass before proceeding
 
+## Pipeline Resolution
+
+The orchestrator supports pluggable pipelines. When starting a task:
+
+1. Read the task manifest from `.forge/store/tasks/{TASK_ID}.json`.
+2. If `task.pipeline` is set, look up that key in `.forge/config.json` → `pipelines`.
+3. If found, use the phases defined in that pipeline.
+4. If `task.pipeline` is not set or the key is not found, use the `default` pipeline
+   (either from `config.pipelines.default` or the hardcoded default below).
+
+Each phase in a pipeline has:
+- `command` — the slash command to invoke (passed the task ID as argument)
+- `role` — semantic role (`plan`, `review-plan`, `implement`, `review-code`, `approve`, `commit`)
+- `maxIterations` — for review roles, the revision loop limit (default 3)
+
+Review roles (`review-plan`, `review-code`) trigger revision loops: if the
+review verdict is "Revision Required", the orchestrator routes back to the
+preceding phase (up to `maxIterations`).
+
 ## Default Pipeline
 
 ```
 plan → review-plan → [loop max 3] → implement → review-implementation → [loop max 3] → approve → writeback → commit
 ```
+
+When no `pipelines` section exists in config, the orchestrator uses this
+hardcoded default. Projects that define `config.pipelines.default` override it.
 
 ## Iron Laws
 

--- a/forge/meta/workflows/meta-sprint-plan.md
+++ b/forge/meta/workflows/meta-sprint-plan.md
@@ -29,6 +29,10 @@ For each task:
 ### Step 4 — Create Sprint Manifest
 - Write sprint JSON to .forge/store/sprints/
 - Write task JSONs to .forge/store/tasks/
+  - If `config.pipelines` defines named pipelines, check whether each task matches
+    a non-default pipeline (by task description, output artifacts, or domain pattern).
+    If so, set `task.pipeline` to the matching pipeline name. When uncertain, omit the
+    field (the orchestrator will use the default pipeline).
 - Create task artifact directories in engineering/sprints/{SPRINT_ID}/
 
 ### Step 5 — Generate Task Prompts

--- a/forge/sdlc-config.schema.json
+++ b/forge/sdlc-config.schema.json
@@ -87,7 +87,7 @@
     },
     "pipeline": {
       "type": "object",
-      "description": "Optional pipeline customisation",
+      "description": "Optional pipeline customisation for the default pipeline",
       "properties": {
         "skipPhases": {
           "type": "array",
@@ -98,6 +98,71 @@
           "default": 3
         }
       }
+    },
+    "pipelines": {
+      "type": "object",
+      "description": "Named pipeline definitions. Each key is a pipeline name that tasks can reference via their `pipeline` field. The `default` pipeline is used when a task has no `pipeline` field. Projects define custom pipelines to route tasks to specialized agent commands.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["phases"],
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of when to use this pipeline"
+          },
+          "phases": {
+            "type": "array",
+            "description": "Ordered list of pipeline phases. Each phase maps to a slash command.",
+            "items": {
+              "type": "object",
+              "required": ["command", "role"],
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "description": "Slash command name (without /) to invoke for this phase"
+                },
+                "role": {
+                  "type": "string",
+                  "enum": ["plan", "review-plan", "implement", "review-code", "approve", "commit"],
+                  "description": "Semantic role of this phase in the pipeline lifecycle"
+                },
+                "model": {
+                  "type": "string",
+                  "description": "Optional model override for this phase"
+                },
+                "maxIterations": {
+                  "type": "integer",
+                  "description": "Max revision loop iterations for review phases",
+                  "default": 3
+                }
+              }
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "default": {
+            "phases": [
+              {"command": "engineer", "role": "plan"},
+              {"command": "supervisor", "role": "review-plan"},
+              {"command": "implement", "role": "implement"},
+              {"command": "supervisor", "role": "review-code"},
+              {"command": "approve", "role": "approve"},
+              {"command": "commit", "role": "commit"}
+            ]
+          },
+          "measure-conversion": {
+            "description": "Specialized pipeline for HEDIS measure encoding",
+            "phases": [
+              {"command": "convert-measure", "role": "implement"},
+              {"command": "review-measure", "role": "review-code"},
+              {"command": "approve-measure", "role": "approve"},
+              {"command": "commit", "role": "commit"}
+            ]
+          }
+        }
+      ]
     },
     "installedSkills": {
       "type": "array",


### PR DESCRIPTION
## Summary

- Adds a `pipelines` registry to `sdlc-config.schema.json` so projects can define named pipelines mapping to custom slash commands
- Adds an optional `pipeline` field to task manifests so individual tasks can declare which pipeline to use
- Updates the meta-orchestrate workflow to resolve `task.pipeline` against `config.pipelines` before dispatching phases
- Updates the sprint planner to assign pipeline fields when tasks match non-default pipeline definitions
- Fully backward compatible: absent field or config falls back to the existing default pipeline

## Motivation

When a project creates specialized agent commands for a recurring task pattern (e.g., converting specs to artifacts, migrating schemas, generating client code), the orchestration workflows have no way to route tasks to those agents. Every task goes through the same generic plan → review → implement → review → approve → commit pipeline.

This forces users to either manually invoke specialized commands outside the sprint/task system, or watch generic agents do work that purpose-built agents would do better.

## Changes

| File | Change |
|------|--------|
| `forge/sdlc-config.schema.json` | Add `pipelines` object with phase schema (command, role, model, maxIterations) |
| `forge/meta/store-schema/task.schema.md` | Add optional `pipeline` field |
| `forge/meta/workflows/meta-orchestrate.md` | Add Pipeline Resolution section |
| `forge/init/generation/generate-orchestration.md` | Instruct generator to wire pipeline routing |
| `forge/meta/workflows/meta-sprint-plan.md` | Sprint planner assigns pipeline to matching tasks |

## Example usage

```json
// .forge/config.json
{
  "pipelines": {
    "measure-conversion": {
      "description": "HEDIS measure encoding pipeline",
      "phases": [
        {"command": "convert-measure", "role": "implement"},
        {"command": "review-measure", "role": "review-code"},
        {"command": "approve-measure", "role": "approve"},
        {"command": "commit", "role": "commit"}
      ]
    }
  }
}

// .forge/store/tasks/HEDIS-S02-3.json
{
  "task_id": "HEDIS-S02-3",
  "title": "Convert PSA measure to JSON",
  "pipeline": "measure-conversion"
}
```

Closes #3

## Test plan

- [ ] Verify existing projects without `pipelines` config continue to use default pipeline
- [ ] Verify `task.pipeline` field is optional and ignored when absent
- [ ] Verify orchestrator resolves named pipeline and invokes correct commands
- [ ] Verify sprint planner assigns pipeline field when config defines custom pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)