### PR TITLE
feat: extend /forge:regenerate with tools and knowledge-base categories

### DIFF
--- a/forge/commands/regenerate.md
+++ b/forge/commands/regenerate.md
@@ -1,36 +1,174 @@
 ---
-description: Use when the engineering knowledge base has been enriched by sprints and you want to refresh the generated workflows and templates
+description: Use when the engineering knowledge base has been enriched by sprints and you want to refresh the generated workflows, templates, tools, or knowledge-base docs
 ---
 
 # /forge:regenerate
 
-Re-run the generation phases using the **current** knowledge base — enriched by N sprints
-of agent writeback — to produce workflows and templates that are richer than Day 1's.
+Re-run generation phases using the current state of the project.
 
-## What this does
+## Locate the Forge plugin
 
-First, resolve the plugin root:
 ```
 FORGE_ROOT: !`echo "${CLAUDE_PLUGIN_ROOT}"`
 ```
 
-1. Read `.forge/config.json` for project configuration
-2. Read the current `engineering/` knowledge base (architecture, business domain, stack checklist)
-3. Read the Forge plugin's `meta/` definitions from `$FORGE_ROOT/meta/`
-4. Re-generate:
-   - `.forge/workflows/` — from meta-workflows + enriched knowledge base
-   - `.forge/templates/` — from meta-templates + enriched knowledge base
-5. Show diffs between current and regenerated files
-6. Prompt before overwriting — never auto-replace
-
-## Important
-
-- Do NOT regenerate `.claude/commands/`, `engineering/tools/`, or `.forge/config.json`
-- Do NOT touch the knowledge base — it is the input, not an output
-- Preserve any manual edits the team has made (show diffs, let the user decide)
+Read `.forge/config.json`. If it does not exist, stop and tell the user to run
+`/forge:init` first.
 
 ## Arguments
 
 $ARGUMENTS
 
-If the user specifies a component (e.g., "workflows" or "templates"), regenerate only that.
+Parse the argument to identify the target category and optional sub-target:
+
+```
+/forge:regenerate                          # workflows + templates (default)
+/forge:regenerate workflows                # atomic workflows + orchestration
+/forge:regenerate templates                # document templates only
+/forge:regenerate tools                    # engineering/tools/ only
+/forge:regenerate knowledge-base           # all three sub-targets (merge mode)
+/forge:regenerate knowledge-base architecture
+/forge:regenerate knowledge-base business-domain
+/forge:regenerate knowledge-base stack-checklist
+```
+
+---
+
+## Category: `workflows` — full rebuild
+
+Re-generate `.forge/workflows/` from the meta-workflow definitions and the
+current knowledge base. Covers both atomic workflows (Phase 5) and
+orchestration (Phase 6).
+
+1. Read `$FORGE_ROOT/meta/workflows/` — all meta-workflow files
+2. Read `$FORGE_ROOT/meta/workflows/meta-orchestrate.md`
+3. Read the current knowledge base in `engineering/` (architecture, business
+   domain, stack checklist) — this is the input, not an output
+4. Read `.forge/config.json` for paths, commands, and pipeline configuration
+5. Re-generate `.forge/workflows/` following
+   `$FORGE_ROOT/init/generation/generate-workflows.md` and
+   `$FORGE_ROOT/init/generation/generate-orchestration.md`
+6. Show a unified diff between current and regenerated files
+7. Prompt before overwriting each file — never auto-replace
+
+**Do NOT touch:** `.claude/commands/`, `engineering/tools/`, `.forge/config.json`,
+or any knowledge base file.
+
+---
+
+## Category: `templates` — full rebuild
+
+Re-generate `.forge/templates/` from the meta-template definitions and the
+current knowledge base.
+
+1. Read `$FORGE_ROOT/meta/templates/` — all meta-template files
+2. Read the current knowledge base in `engineering/`
+3. Re-generate `.forge/templates/` following
+   `$FORGE_ROOT/init/generation/generate-templates.md`
+4. Show diffs and prompt before overwriting
+
+---
+
+## Category: `tools` — full rebuild
+
+Re-generate `engineering/tools/` from the tool specs and current config.
+Safe to rebuild from scratch — inputs are fully deterministic.
+
+1. Read all `$FORGE_ROOT/meta/tool-specs/*.spec.md`
+2. Read `.forge/config.json` for the project's primary language and paths
+3. Re-generate `engineering/tools/` following
+   `$FORGE_ROOT/init/generation/generate-tools.md`
+4. Show diffs and prompt before overwriting
+
+**When to use:** a new tool spec has been added (e.g., after a Forge update),
+or the project has switched its primary language.
+
+---
+
+## Category: `knowledge-base` — merge mode
+
+**This is not a full rebuild.** The knowledge base accumulates writeback from
+every sprint. Overwriting it from scratch destroys that accumulated knowledge.
+
+Instead: re-run the relevant discovery prompts scoped to what has changed,
+compute a delta against the existing docs, and merge only new content in.
+
+**Merge rule (applies to all sub-targets):**
+- Additive only — never remove or overwrite existing sections or entries.
+- `[?]` markers from prior generation may be updated if the re-scan can now
+  confirm or correct them.
+- If the re-scan detects something that contradicts existing content, flag it
+  as a `[CONFLICT]` comment for human review — do not resolve it silently.
+- Show all proposed additions as a diff and prompt before writing.
+
+---
+
+### Sub-target: `architecture`
+
+**Trigger:** new subsystems, services, or integrations have been added to the
+codebase since the architecture docs were last written.
+
+**Re-run discovery (in parallel):**
+- `$FORGE_ROOT/init/discovery/discover-stack.md`
+- `$FORGE_ROOT/init/discovery/discover-processes.md`
+- `$FORGE_ROOT/init/discovery/discover-routing.md`
+
+**Read existing docs:**
+- `engineering/architecture/*.md`
+
+**Merge into:**
+
+| Discovery output | Target doc | Merge action |
+|-----------------|-----------|-------------|
+| New framework or runtime | `stack.md` | Append to technology inventory |
+| New service or process | `processes.md` | Append new service section |
+| New API route group | `routing.md` | Append route group |
+| New deployment target | `deployment.md` | Append environment section |
+| Any new sub-system with no existing doc | Create new sub-doc + link from `INDEX.md` |
+
+---
+
+### Sub-target: `business-domain`
+
+**Trigger:** new ORM models, schema tables, or domain types have been added
+to the codebase. `forge:health` will flag these as orphaned entities.
+
+**Re-run discovery:**
+- `$FORGE_ROOT/init/discovery/discover-database.md`
+
+**Read existing doc:**
+- `engineering/business-domain/entity-model.md`
+
+**Merge into `entity-model.md`:**
+- Entities present in discovery output but absent from the doc → append new
+  entity sections with fields and relationships.
+- New fields on an existing entity → add within the existing entity section,
+  marked `[NEW]` for team review.
+- Entities no longer found in the codebase → flag with `[NOT FOUND IN SCAN]`
+  comment but do not remove (may be soft-deleted, feature-flagged, or in a
+  migration).
+
+---
+
+### Sub-target: `stack-checklist`
+
+**Trigger:** new libraries or frameworks have been adopted mid-project that
+are not yet represented in review checklist items.
+
+**Re-run discovery:**
+- `$FORGE_ROOT/init/discovery/discover-stack.md`
+- `$FORGE_ROOT/init/discovery/discover-testing.md`
+
+**Read existing doc:**
+- `engineering/stack-checklist.md`
+
+**Merge into `stack-checklist.md`:**
+- Libraries detected but not yet in the checklist → append new checklist items.
+- Never remove or modify existing items (they encode accumulated review knowledge).
+
+---
+
+## Default (no argument)
+
+Run `workflows` + `templates` in sequence. This preserves the pre-existing
+behaviour for callers that do not pass an argument.


### PR DESCRIPTION
## Summary

Extends `/forge:regenerate` from two coarse categories (`workflows`, `templates`) to five, with appropriate modes for each:

| Category | Mode | When to use |
|---|---|---|
| `workflows` | Full rebuild | Meta-workflow or orchestration changes |
| `templates` | Full rebuild | Meta-template changes |
| `tools` | Full rebuild | New tool spec added, or language change |
| `knowledge-base` | Merge | New entities, subsystems, or libraries added mid-project |
| `knowledge-base architecture` | Merge (scoped) | New services, routes, or processes |
| `knowledge-base business-domain` | Merge (scoped) | New ORM models or schema tables |
| `knowledge-base stack-checklist` | Merge (scoped) | New libraries adopted mid-sprint |

## Motivation

The existing command treated the knowledge base the same as workflows — as output to be rebuilt from scratch. That is wrong: the KB accumulates writeback from every sprint. Overwriting it loses that knowledge.

The correct model for KB categories is additive merge: re-run scoped discovery prompts, compute a delta, and fold in only what is new. Contradictions between fresh discovery and existing content are flagged `[CONFLICT]` for human review rather than resolved silently.

`tools` is the opposite case — fully deterministic inputs (specs + config), safe to rebuild at any time, needed now that `manage-config` has been added as a spec.

## Merge rules (knowledge-base)

- Additive only — never remove or overwrite existing sections
- `[?]` markers updated if now resolvable
- Contradictions flagged `[CONFLICT]`, not auto-resolved
- New entities marked `[NEW]` for team review
- Vanished entities flagged `[NOT FOUND IN SCAN]`, not deleted
- All proposed additions shown as diff before writing

## Default behaviour unchanged

`/forge:regenerate` with no argument still runs `workflows` + `templates`.

## Test plan

- [ ] Verify `tools` rebuilds `engineering/tools/` without touching knowledge base or config
- [ ] Verify `knowledge-base business-domain` appends new entities and does not overwrite existing ones
- [ ] Verify `knowledge-base architecture` appends new subsystems and flags contradictions as `[CONFLICT]`
- [ ] Verify `knowledge-base stack-checklist` appends new items and does not remove existing ones
- [ ] Verify default (no argument) behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)